### PR TITLE
submodule extension for ctypes::dll

### DIFF
--- a/vm/src/stdlib/ctypes/dll.rs
+++ b/vm/src/stdlib/ctypes/dll.rs
@@ -1,45 +1,53 @@
-use crate::builtins::pystr::PyStrRef;
-use crate::builtins::PyIntRef;
-use crate::pyobject::{PyResult, TryFromObject};
-use crate::VirtualMachine;
+pub(crate) use _ctypes::*;
 
-use super::shared_lib::libcache;
+#[pymodule]
+pub(crate) mod _ctypes {
+    use crate::builtins::pystr::PyStrRef;
+    use crate::builtins::PyIntRef;
+    use crate::pyobject::{PyResult, TryFromObject};
+    use crate::VirtualMachine;
 
-pub fn dlopen(lib_path: PyStrRef, vm: &VirtualMachine) -> PyResult {
-    let mut data_cache = libcache().write();
+    use super::super::shared_lib::libcache;
 
-    let result = data_cache.get_or_insert_lib(lib_path.as_ref(), vm);
+    #[pyfunction]
+    pub fn dlopen(lib_path: PyStrRef, vm: &VirtualMachine) -> PyResult {
+        let mut data_cache = libcache().write();
 
-    match result {
-        Ok(lib) => Ok(vm.new_pyobj(lib.get_pointer())),
-        Err(_) => Err(vm.new_os_error(format!(
-            "{} : cannot open shared object file: No such file or directory",
-            lib_path.to_string()
-        ))),
-    }
-}
+        let result = data_cache.get_or_insert_lib(lib_path.as_ref(), vm);
 
-pub fn dlsym(slib: PyIntRef, str_ref: PyStrRef, vm: &VirtualMachine) -> PyResult {
-    let func_name = str_ref.as_ref();
-    let data_cache = libcache().read();
-
-    match data_cache.get_lib(usize::try_from_object(vm, slib.as_object().clone())?) {
-        Some(l) => match l.get_sym(func_name) {
-            Ok(ptr) => Ok(vm.new_pyobj(ptr as *const _ as usize)),
-            Err(e) => Err(vm.new_runtime_error(e)),
-        },
-        _ => Err(vm.new_runtime_error("not a valid pointer to a shared library".to_string())),
-    }
-}
-
-pub fn dlclose(slib: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
-    let data_cache = libcache().read();
-
-    match data_cache.get_lib(usize::try_from_object(vm, slib.as_object().clone())?) {
-        Some(l) => {
-            l.close();
-            Ok(())
+        match result {
+            Ok(lib) => Ok(vm.new_pyobj(lib.get_pointer())),
+            Err(_) => Err(vm.new_os_error(format!(
+                "{} : cannot open shared object file: No such file or directory",
+                lib_path.to_string()
+            ))),
         }
-        _ => Err(vm.new_runtime_error("not a valid pointer to a shared library".to_string())),
+    }
+
+    #[pyfunction]
+    pub fn dlsym(slib: PyIntRef, str_ref: PyStrRef, vm: &VirtualMachine) -> PyResult {
+        let func_name = str_ref.as_ref();
+        let data_cache = libcache().read();
+
+        match data_cache.get_lib(usize::try_from_object(vm, slib.as_object().clone())?) {
+            Some(l) => match l.get_sym(func_name) {
+                Ok(ptr) => Ok(vm.new_pyobj(ptr as *const _ as usize)),
+                Err(e) => Err(vm.new_runtime_error(e)),
+            },
+            _ => Err(vm.new_runtime_error("not a valid pointer to a shared library".to_string())),
+        }
+    }
+
+    #[pyfunction]
+    pub fn dlclose(slib: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
+        let data_cache = libcache().read();
+
+        match data_cache.get_lib(usize::try_from_object(vm, slib.as_object().clone())?) {
+            Some(l) => {
+                l.close();
+                Ok(())
+            }
+            _ => Err(vm.new_runtime_error("not a valid pointer to a shared library".to_string())),
+        }
     }
 }

--- a/vm/src/stdlib/ctypes/mod.rs
+++ b/vm/src/stdlib/ctypes/mod.rs
@@ -12,7 +12,6 @@ mod structure;
 
 use array::PyCArray;
 use basics::{addressof, alignment, byref, sizeof_func, PyCData};
-use dll::*;
 use function::PyCFuncPtr;
 use pointer::{pointer_fn, PyCPointer, POINTER};
 use primitive::{PyCSimpleType, PySimpleType};
@@ -23,12 +22,8 @@ pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     PyCData::make_class(ctx);
     PyCSimpleType::make_class(ctx);
 
-    py_module!(vm, "_ctypes", {
+    let module = py_module!(vm, "_ctypes", {
         "__version__" => ctx.new_str("1.1.0"),
-
-        "dlopen" => ctx.new_function("dlopen", dlopen),
-        "dlsym" => ctx.new_function("dlsym", dlsym),
-        "dlclose" => ctx.new_function("dlclose", dlclose),
 
         "alignment" => ctx.new_function("alignment", alignment),
         "sizeof" => ctx.new_function("sizeof", sizeof_func),
@@ -44,5 +39,9 @@ pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         "_Pointer" => PyCPointer::make_class(ctx),
         "Array" => PyCArray::make_class(ctx),
         "Struct" => PyCStructure::make_class(ctx)
-    })
+    });
+
+    dll::extend_module(vm, &module);
+
+    module
 }


### PR DESCRIPTION
Here is another suggestion.

Instead of manually consisting of full `_ctypes` module, you can define a few submodules and combine it using `extend_module`